### PR TITLE
Added images to the questions

### DIFF
--- a/TriviaGame/Data/answers.json
+++ b/TriviaGame/Data/answers.json
@@ -83,26 +83,6 @@
 		{
 			"questionID": "q9",
 			"answers": [
-				"The dev team’s commitment to doing quality work on every task during a sprint.",
-				"List of features the Product Owner wants completed in a sprint.",
-				"Checklist the Scrum Master uses to determine if the team met their commitments.",
-				"Agreement that team members will try to finish tasks before the sprint ends."
-			],
-			"correct": "The dev team’s commitment to doing quality work on every task during a sprint."
-		},
-		{
-			"questionID": "q10",
-			"answers": [
-				"Ensures that developers work overtime if the sprint goal is at risk.",
-				"Manages the team’s performance reviews and approves time off requests.",
-				"Assign tasks to team members and making sure everyone meets deadlines.",
-				"Facilitate the Scrum process by helping the team follow Scrum practices, removing impediments, and fostering a culture of continuous improvement."
-			],
-			"correct": "Facilitate the Scrum process by helping the team follow Scrum practices, removing impediments, and fostering a culture of continuous improvement."
-		},
-		{
-			"questionID": "q11",
-			"answers": [
 				"Fortnite",
 				"Rocket League",
 				"League of Legends",
@@ -111,7 +91,7 @@
 			"correct": "Rocket League"
 		},
 		{
-			"questionID": "q12",
+			"questionID": "q10",
 			"answers": [
 				"212F",
 				"100F",
@@ -121,7 +101,7 @@
 			"correct": "212F"
 		},
 		{
-			"questionID": "q13",
+			"questionID": "q11",
 			"answers": [
 				"Ionic Bond",
 				"Hydrogen Bond",
@@ -131,7 +111,7 @@
 			"correct": "Covalent Bond"
 		},
 		{
-			"questionID": "q14",
+			"questionID": "q12",
 			"answers": [
 				"Lobster Flatbread",
 				"Popcorn Shrimp",
@@ -141,7 +121,7 @@
 			"correct": "Bacon Wrapped Scallops"
 		},
 		{
-			"questionID": "q15",
+			"questionID": "q13",
 			"answers": [
 				"Scrum Master",
 				"Cop",
@@ -151,7 +131,7 @@
 			"correct": "Cop"
 		},
 		{
-			"questionID": "q16",
+			"questionID": "q14",
 			"answers": [
 				"The Witcher 3: Wild Hunt",
 				"Terraria",
@@ -161,7 +141,7 @@
 			"correct": "The Witcher 3: Wild Hunt"
 		},
 		{
-			"questionID": "q17",
+			"questionID": "q15",
 			"answers": [
 				"Minecraft",
 				"Terraria",
@@ -171,7 +151,7 @@
 			"correct": "Tetris"
 		},
 		{
-			"questionID": "q18",
+			"questionID": "q16",
 			"answers": [
 				"LocalThunk",
 				"Playstack",
@@ -181,7 +161,7 @@
 			"correct": "LocalThunk"
 		},
 		{
-			"questionID": "q19",
+			"questionID": "q17",
 			"answers": [
 				"Dominic Sessa",
 				"Paul Giamatti",
@@ -191,7 +171,7 @@
 			"correct": "Paul Giamatti"
 		},
 		{
-			"questionID": "q20",
+			"questionID": "q18",
 			"answers": [
 				"Clarence Macklin",
 				"Hamish Linklater",
@@ -201,7 +181,7 @@
 			"correct": "Colman Domingo"
 		},
 		{
-			"questionID": "q21",
+			"questionID": "q19",
 			"answers": [
 				"Stephen King",
 				"David Fincher",

--- a/TriviaGame/Data/questions.json
+++ b/TriviaGame/Data/questions.json
@@ -3,107 +3,135 @@
 		{
 			"questionID": "q1",
 			"category": "ETSU",
-			"questionText": "What year was ETSU founded?"
+			"questionText": "What year was ETSU founded?",
+			"questionImageAddress": "https://www.etsu.edu/fachistory/pictures/gilbreath-arial-2_cropped.jpg",
+			"questionDescription": "Image of ETSU's campus."
 		},
 		{
 			"questionID": "q2",
 			"category": "ETSU",
-			"questionText": "What was the previous name of the Brinkley Center?"
+			"questionText": "What was the previous name of the Brinkley Center?",
+			"questionImageAddress": "https://communitytectonics.com/wp-content/uploads/2019/08/IMG_5132-scaled.jpg",
+			"questionDescription": "Image inside the ETSU Brinkley Center."
 		},
 		{
 			"questionID": "q3",
 			"category": "ETSU",
-			"questionText": "What is the name of the building with the dining hall and Buc Mart?"
+			"questionText": "What is the name of the building with the dining hall and Buc Mart?",
+			"questionImageAddress": "https://i0.wp.com/easttennessean.com/wp-content/uploads/2023/08/ETSU-Dining-Hall-ContributedETSU.jpg?fit=2000%2C1050&ssl=1",
+			"questionDescription": "Image of ETSU's dinning hall."
 		},
 		{
 			"questionID": "q4",
 			"category": "ETSU",
-			"questionText": "Where did the name Pepper's Grill come from?"
+			"questionText": "Where did the name Pepper's Grill come from?",
+			"questionImageAddress": "https://www.wjhl.com/wp-content/uploads/sites/98/2025/01/IMG_0195.jpg?strip=1&w=640",
+			"questionDescription": "Image of Pepper's Grill."
 		},
 		{
 			"questionID": "q5",
 			"category": "ETSU",
-			"questionText": "What are our sports teams named?"
+			"questionText": "What are our sports teams named?",
+			"questionImageAddress": "https://www.etsu.edu/esports/pictures/rocketleague/1-content-square.png",
+			"questionDescription": "Image of Landen_rl."
 		},
 		{
 			"questionID": "q6",
 			"category": "Gaming",
-			"questionText": "When did the Nintendo GameCube come out in North America?"
+			"questionText": "When did the Nintendo GameCube come out in North America?",
+			"questionImageAddress": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSaO6qZCyDzqiQ-DXar38TK9n2DvmQhBaoCZA&s",
+			"questionDescription": "Image of space."
 		},
 		{
 			"questionID": "q7",
 			"category": "Kinser",
-			"questionText": "What language was Kinser's first program made for money written in?"
+			"questionText": "What language was Kinser's first program made for money written in?",
+			"questionImageAddress": "https://miro.medium.com/v2/resize:fit:1400/0*kmYC7KFe-CgTAJ7A",
+			"questionDescription": "Image of random lines of code."
 		},
 		{
 			"questionID": "q8",
 			"category": "Kinser",
-			"questionText": "What company did Kinser land his first professional programmer job with?"
+			"questionText": "What company did Kinser land his first professional programmer job with?",
+			"questionImageAddress": "https://images.pexels.com/photos/2382848/pexels-photo-2382848.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
+			"questionDescription": "Image of a plane."
 		},
 		{
 			"questionID": "q9",
-			"category": "Scrum",
-			"questionText": "What is the Definition of Done?"
+			"category": "ETSU",
+			"questionText": "What game is played by ETSU Esports?",
+			"questionImageAddress": "https://images.pexels.com/photos/114296/pexels-photo-114296.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
+			"questionDescription": "Image of soccer."
 		},
 		{
 			"questionID": "q10",
-			"category": "Scrum",
-			"questionText": "What is the job of the Scrum Master?"
+			"category": "Chemistry",
+			"questionText": "What is the boiling point of water?",
+			"questionImageAddress": "https://images.pexels.com/photos/6831122/pexels-photo-6831122.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
+			"questionDescription": "Image of a pot on a portable stove."
 		},
 		{
 			"questionID": "q11",
-			"category": "ETSU",
-			"questionText": "What game is played by ETSU Esports?"
+			"category": "Chemistry",
+			"questionText": "What type of bond is formed when electrons are shared between two atoms?",
+			"questionImageAddress": "https://images.pexels.com/photos/414860/pexels-photo-414860.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
+			"questionDescription": "Image of a plasma globe."
 		},
 		{
 			"questionID": "q12",
-			"category": "Chemistry",
-			"questionText": "What is the boiling point of water?"
+			"category": "ETSU",
+			"questionText": "What is Ramsey's favorite Red Lobster food item?",
+			"questionImageAddress": "https://images.pexels.com/photos/8352391/pexels-photo-8352391.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
+			"questionDescription": "Image of lobsters."
 		},
 		{
 			"questionID": "q13",
-			"category": "Chemistry",
-			"questionText": "What type of bond is formed when electrons are shared between two atoms?"
+			"category": "ETSU",
+			"questionText": "What was Ramsey's job before being a ETSU Professor?",
+			"questionImageAddress": "https://images.pexels.com/photos/28771663/pexels-photo-28771663/free-photo-of-cowboy-teddy-bear-with-punk-t-shirt-in-theme-room.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
+			"questionDescription": "Image of a sheriff bear."
 		},
 		{
 			"questionID": "q14",
-			"category": "John Ramsey",
-			"questionText": "What is Ramsey's favorite Red Lobster food item?"
+			"category": "Gaming",
+			"questionText": "What was the game of the year in 2015?",
+			"questionImageAddress": "https://images.pexels.com/photos/6301/fireworks-new-year-new-2015.jpg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
+			"questionDescription": "Image of sparklers spelling out 2015."
 		},
 		{
 			"questionID": "q15",
-			"category": "John Ramsey",
-			"questionText": "What was Ramsey's job before being a ETSU Professor?"
+			"category": "Gaming",
+			"questionText": "What is the best-selling game of all time? (By Copies Sold)",
+			"questionImageAddress": "https://images.pexels.com/photos/1340185/pexels-photo-1340185.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
+			"questionDescription": "Image of a orange block."
 		},
 		{
 			"questionID": "q16",
 			"category": "Gaming",
-			"questionText": "What was the game of the year in 2015?"
+			"questionText": "Who is the developer of Balatro?",
+			"questionImageAddress": "https://images.pexels.com/photos/6664193/pexels-photo-6664193.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
+			"questionDescription": "Image of cards spread out on a surface."
 		},
 		{
 			"questionID": "q17",
-			"category": "Gaming",
-			"questionText": "What is the best-selling game of all time? (By Copies Sold)"
+			"category": "Movies",
+			"questionText": "Who plays Professor Paul Hunham in The Holdovers (2023)?",
+			"questionImageAddress": "https://images.pexels.com/photos/625219/pexels-photo-625219.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
+			"questionDescription": "Image of a chaulk board."
 		},
 		{
 			"questionID": "q18",
-			"category": "Gaming",
-			"questionText": "Who is the developer of Balatro?"
+			"category": "Movies",
+			"questionText": "Who is the actor in the leading role of Sing Sing (2023)?",
+			"questionImageAddress": "https://images.pexels.com/photos/6064891/pexels-photo-6064891.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
+			"questionDescription": "Image of a prison cell."
 		},
 		{
 			"questionID": "q19",
-			"category": "Movies",
-			"questionText": "Who plays Professor Paul Hunham in The Holdovers (2023)?"
-		},
-		{
-			"questionID": "q20",
-			"category": "Movies",
-			"questionText": "Who is the actor in the leading role of Sing Sing (2023)?"
-		},
-		{
-			"questionID": "q21",
 			"category": "Movies and TV",
-			"questionText": "Who is the director of Netflix shows The Haunting of Hill House, The Haunting of Bly Manor, Midnight Mass, and The Fall of the House of Usher?"
+			"questionText": "Who is the director of Netflix shows The Haunting of Hill House, The Haunting of Bly Manor, Midnight Mass, and The Fall of the House of Usher?",
+			"questionImageAddress": "https://images.pexels.com/photos/10082743/pexels-photo-10082743.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
+			"questionDescription": "Image of a person with a white sheet over their head."
 		}
 	]
 }

--- a/TriviaGame/Scripts/main.js
+++ b/TriviaGame/Scripts/main.js
@@ -3,7 +3,7 @@
 // Get the file paths of our questions and answers
 const questionURL = './Data/questions.json';
 const answerURL = './Data/answers.json';
-const questionId = 0;
+const questionId = 16;
 
 // We'll store references to the buttons, correct answer, and correctness
 let buttons = [];
@@ -18,15 +18,19 @@ async function loadQuestionAndAnswers() {
         // 1. Fetch question JSON
         const qResponse = await fetch(questionURL);
         const qData = await qResponse.json();
-        const questionText = qData.question[questionId].questionText;
+        const questionText = qData.question[questionId - 1].questionText;
+        const questionImageAddress = qData.question[questionId - 1].questionImageAddress;
+        const questionDescription = qData.question[questionId - 1].questionDescription;
 
         // Put it in the <h1 id="questionText">
         document.getElementById('questionText').textContent = questionText;
+        document.getElementById('questionImage').src = questionImageAddress;
+        document.getElementById('questionImage').alt = questionDescription;
 
         // 2. Fetch answer JSON
         const aResponse = await fetch(answerURL);
         const aData = await aResponse.json();
-        const answerObj = aData.answer[questionId];
+        const answerObj = aData.answer[questionId - 1];
 
         correctAnswer = answerObj.correct;
         const answers = answerObj.answers;

--- a/TriviaGame/Style/game.css
+++ b/TriviaGame/Style/game.css
@@ -10,7 +10,17 @@
     max-width: 800px;
     max-height: 400px;
     background-color: lightblue;
-    padding: 20px;
+    padding: 5px;
+}
+
+/**
+ * Used to change the styling of the question's image.
+ * 
+ * #ID questionImage
+ */
+#questionImage {
+    max-width: 115px;
+    max-height: 115px;
 }
 
 /**
@@ -23,7 +33,7 @@
     margin: 10px 0;
     padding: 10px;
     width: 200px;
-    font-size: 16px;
+    font-size: 12px;
 }
 
 /**

--- a/TriviaGame/game.html
+++ b/TriviaGame/game.html
@@ -10,7 +10,9 @@
 <body>
     <div id="GameZone">
         <!-- Display the question here -->
-        <h1 id="questionText"></h1>
+        <h3 id="questionText"></h3>
+
+        <img id="questionImage" src="" alt="" width="125" height="125">
 
         <form action="results.html" method="GET">
             <div id="answers">

--- a/TriviaGame/results.html
+++ b/TriviaGame/results.html
@@ -21,9 +21,9 @@
 <body>
 
     <div id="GameZone">
-        <h2 id="questionText"></h2>
+        <h3 id="questionText"></h3>
 
-        <h2 id="selectedAnswer"></h2>
+        <h3 id="selectedAnswer"></h3>
 
         <h1 id="correct"></h1>
 


### PR DESCRIPTION
**Test Case ID's**
- TC_12
- TC_13
- TC_14
- TC_15
- TC_16
- TC_17
- TC_18

**Few things to note**

- I removed two questions due to length, both created by me and were the ones related to scrum
- JSON file has two new fields, one for the image address and another for the image description which will only be displayed if the image somehow fails to load.
- currently the images are set to 115px by 115px but this doesn't work for all questions, there's some overflow. Possibly to fix this next sprint when we are stylizing the page we can have the image moved to the right of the questions or have the questions in a 2x2 grid.
- I changed a few of the header tags around to change the sizing a bit to help with fitting the image on the screen.